### PR TITLE
Automatic GH actions virion loading

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         echo Directory made.
     - name: Print php version
       run: |
-        php -r 'var_dump(yaml_parse_file(".poggit.yml"))'
+        php -r 'var_dump(yaml_parse_file(".poggit.yml"));'
     - name: wget virions, customui
       uses: wei/wget@v1
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
     - name: Print php version
       run: |
         php -v
+        ls -r
     - name: wget virions, customui
       uses: wei/wget@v1
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       run: |
         php -f resources/parsepoggit.php > virion_urls.txt
         cat virion_urls.txt
-        wget -P vendor --restrict-file-names=nocontrol --content-disposition -i virion_urls.txt
+        wget -P vendor --content-disposition -i virion_urls.txt
         rm virion_urls.txt
     - name: Run PHPStan
       uses: nxtlvlsoftware/pmmp-phpstan-action@4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,29 +14,32 @@ jobs:
         echo Making directory...
         mkdir vendor
         echo Directory made.
-    - name: Print php version
+    - name: Download virions to vendor
       run: |
-        php -r 'var_dump(yaml_parse_file(".poggit.yml"));'
-    - name: wget virions, customui
-      uses: wei/wget@v1
-      with:
-        args: -O vendor/customui.phar https://poggit.pmmp.io/r/44509/customui_dev-31.phar
-    - name: wget virions, apibossbar
-      uses: wei/wget@v1
-      with:
-        args: -O vendor/apibossbar.phar https://poggit.pmmp.io/r/64017/apibossbar_dev-2.phar
-    - name: wget virions, libschematic
-      uses: wei/wget@v1
-      with:
-        args: -O vendor/libschematic.phar https://poggit.pmmp.io/r/64630/libschematic_dev-25.phar
-    - name: wget virions, Commando
-      uses: wei/wget@v1
-      with:
-        args: -O vendor/Commando.phar https://poggit.pmmp.io/r/67875/Commando_dev-27.phar
-    - name: wget virions, InvMenu
-      uses: wei/wget@v1
-      with:
-        args: -O vendor/InvMenu.phar https://poggit.pmmp.io/r/70989/InvMenu_dev-78.phar
+        php -f resources/parsepoggit.php > virion_urls.txt
+        cat virion_urls.txt
+        wget -P vendor -i virion_urls.txt
+        rm virion_urls.txt
+      #    - name: wget virions, customui
+      #      uses: wei/wget@v1
+      #      with:
+      #        args: -O vendor/customui.phar https://poggit.pmmp.io/r/44509/customui_dev-31.phar
+      #    - name: wget virions, apibossbar
+      #      uses: wei/wget@v1
+      #      with:
+      #        args: -O vendor/apibossbar.phar https://poggit.pmmp.io/r/64017/apibossbar_dev-2.phar
+      #    - name: wget virions, libschematic
+      #      uses: wei/wget@v1
+      #      with:
+      #        args: -O vendor/libschematic.phar https://poggit.pmmp.io/r/64630/libschematic_dev-25.phar
+      #    - name: wget virions, Commando
+      #      uses: wei/wget@v1
+      #      with:
+      #        args: -O vendor/Commando.phar https://poggit.pmmp.io/r/67875/Commando_dev-27.phar
+      #    - name: wget virions, InvMenu
+      #      uses: wei/wget@v1
+      #      with:
+      #        args: -O vendor/InvMenu.phar https://poggit.pmmp.io/r/70989/InvMenu_dev-78.phar
     - name: Run PHPStan
       uses: nxtlvlsoftware/pmmp-phpstan-action@4
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,9 @@ jobs:
         echo Making directory...
         mkdir vendor
         echo Directory made.
+    - name: Print php version
+      run: |
+        php -v
     - name: wget virions, customui
       uses: wei/wget@v1
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,7 @@ jobs:
         echo Directory made.
     - name: Print php version
       run: |
-        php -v
-        ls -r
+        php -r 'var_dump(yaml_parse_file(".poggit.yml"))'
     - name: wget virions, customui
       uses: wei/wget@v1
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,26 +20,6 @@ jobs:
         cat virion_urls.txt
         wget -P vendor -i virion_urls.txt
         rm virion_urls.txt
-      #    - name: wget virions, customui
-      #      uses: wei/wget@v1
-      #      with:
-      #        args: -O vendor/customui.phar https://poggit.pmmp.io/r/44509/customui_dev-31.phar
-      #    - name: wget virions, apibossbar
-      #      uses: wei/wget@v1
-      #      with:
-      #        args: -O vendor/apibossbar.phar https://poggit.pmmp.io/r/64017/apibossbar_dev-2.phar
-      #    - name: wget virions, libschematic
-      #      uses: wei/wget@v1
-      #      with:
-      #        args: -O vendor/libschematic.phar https://poggit.pmmp.io/r/64630/libschematic_dev-25.phar
-      #    - name: wget virions, Commando
-      #      uses: wei/wget@v1
-      #      with:
-      #        args: -O vendor/Commando.phar https://poggit.pmmp.io/r/67875/Commando_dev-27.phar
-      #    - name: wget virions, InvMenu
-      #      uses: wei/wget@v1
-      #      with:
-      #        args: -O vendor/InvMenu.phar https://poggit.pmmp.io/r/70989/InvMenu_dev-78.phar
     - name: Run PHPStan
       uses: nxtlvlsoftware/pmmp-phpstan-action@4
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       run: |
         php -f resources/parsepoggit.php > virion_urls.txt
         cat virion_urls.txt
-        wget -P vendor -i virion_urls.txt
+        wget -P vendor --restrict-file-names=nocontrol --content-disposition -i virion_urls.txt
         rm virion_urls.txt
     - name: Run PHPStan
       uses: nxtlvlsoftware/pmmp-phpstan-action@4

--- a/.poggit.yml
+++ b/.poggit.yml
@@ -12,10 +12,14 @@ projects:
       version: ^2.0.0
     - src: thebigsmilexd/customui/customui
       version: ^3.0.0
+      branch: PM4
     - src: thebigsmilexd/apibossbar/apibossbar
       version: ^0.0.5
+      branch: PM4
     - src: CortexPE/Commando/Commando
       version: ^0.5.0
+      branch: PM4
     - src: muqsit/invmenu/InvMenu
       version: ^2.0.0
+      branch: 4.0
 ...

--- a/.poggit.yml
+++ b/.poggit.yml
@@ -11,15 +11,15 @@ projects:
     - src: BlockHorizons/libschematic/libschematic
       version: ^2.0.0
     - src: thebigsmilexd/customui/customui
-      version: ^3.0.0
+      version: ^4.0.0
       branch: PM4
     - src: thebigsmilexd/apibossbar/apibossbar
-      version: ^0.0.5
+      version: ^0.1.1
       branch: PM4
     - src: CortexPE/Commando/Commando
-      version: ^0.5.0
+      version: ^3.0.0
       branch: PM4
     - src: muqsit/invmenu/InvMenu
-      version: ^2.0.0
+      version: ^4.0.1
       branch: 4.0
 ...

--- a/.poggit.yml
+++ b/.poggit.yml
@@ -21,5 +21,5 @@ projects:
       branch: PM4
     - src: muqsit/invmenu/InvMenu
       version: ^4.0.1
-      branch: 4.0
+      branch: "4.0"
 ...

--- a/resources/parsepoggit.php
+++ b/resources/parsepoggit.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+$yaml = yaml_parse_file(".poggit.yml");
+
+$urls = [];
+
+foreach ($yaml["projects"] ?? [] as $project) {
+	foreach ($project["libs"] ?? [] as $lib) {
+		$src = $lib["src"] ?? null;
+		if ($src === null) {
+			echo "Missing src in libs";
+			continue;
+		}
+		$version = $lib["version"] ?? "*";
+		$branch = $lib["branch"] ?? ":default";
+
+		$urls[] = "https://poggit.pmmp.io/v.dl/{$src}/{$version}?branch={$branch}";
+	}
+}
+
+print implode('
+', $urls);


### PR DESCRIPTION
This PR modifies the GH action and allows the correct virions required for analysis to be automatically loaded by parsing .poggit.yml.
If this action step throws errors, the virions are outdated and .poggit.yml needs to be updated.